### PR TITLE
Use `linux` via environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ output.log
 ore.bat
 test.exe
 [cC]argo.lock
+linux

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 output.log
 ore.bat
 test.exe
-cargo.lock
+[cC]argo.lock

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ Linux users
 nvcc linux.cu -o linux
 ```
 
-Take the path to the executsble that was just created and replace the PATH_TO_EXE with the path to the .exe in the mine.rs.
+Take the path to the executable that was just created and pass it as an environment variable.
+
+```sh
+export PATH_TO_EXE=./linux
+```
 
 Once you have Rust installed, you can build the Ore CLI by running the following command:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cargo build --release
 
 
 ```sh
-./target/release/ore.exe --rpc "" --priority-fee 1 --keypair 'path to keypair' --priority-fee 1 mine --threads 4
+./target/release/ore.exe --rpc "" --priority-fee 1 --keypair 'path to keypair' mine --threads 4
 ```
 
 You will now run your hashing on the GPU instead of the CPU!

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -1,4 +1,5 @@
 use std::{
+    env,
     io::{stdout, Write,BufRead},
     sync::{atomic::AtomicBool, Arc, Mutex},
     mem
@@ -167,7 +168,7 @@ impl Miner {
         let signer = self.signer();
         let pubkey = signer.pubkey();
 
-    let mut child = tokio::process::Command::new("PATH_TO_EXE")
+    let mut child = tokio::process::Command::new(env::var("PATH_TO_EXE").unwrap())
     .stdin(std::process::Stdio::piped())
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::piped())


### PR DESCRIPTION
This PR makes it possible to pass the path to the `linux` binary via an environment variable.

So if the location changes, it doesn't require one to recompile. I've updated the README with associated instructions.

There's also minor updates to correct an error in the README, to have Git ignore the compiled binary, and fix an existing pattern for the Cargo lock file.