### PR TITLE
Remove unused imports

### DIFF
--- a/src/mine.rs
+++ b/src/mine.rs
@@ -1,12 +1,7 @@
 use std::{
-    io::{stdout, Write,BufRead},
-    sync::{atomic::AtomicBool, Arc, Mutex},
-    mem
+    io::{stdout, Write},
+    sync::{atomic::AtomicBool, Arc, Mutex}
 };
-use std::process::Command;
-use std::str::FromStr;
-use bs58;
-use hex;
 use ore::{self, state::Bus, BUS_ADDRESSES, BUS_COUNT, EPOCH_DURATION};
 use rand::Rng;
 use solana_program::{keccak::HASH_BYTES, program_memory::sol_memcmp, pubkey::Pubkey};
@@ -20,8 +15,7 @@ use crate::{
     utils::{get_clock_account, get_proof, get_treasury},
     Miner,
 };
-use base64::{encode};
-use tokio::io::{AsyncWriteExt, BufReader, AsyncBufReadExt};
+use tokio::io::AsyncWriteExt;
 // Odds of being selected to submit a reset tx
 const RESET_ODDS: u64 = 20;
 


### PR DESCRIPTION
Upon building, there are a number of warnings about unused imports.

This PR removes them to quiet down the build process a little bit, allowing one to focus on actual errors and important warnings.

```
warning: unused imports: `BufRead`, `mem`
 --> src/mine.rs:3:24
  |
3 |     io::{stdout, Write,BufRead},
  |                        ^^^^^^^
4 |     sync::{atomic::AtomicBool, Arc, Mutex},
5 |     mem
  |     ^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `std::process::Command`
 --> src/mine.rs:7:5
  |
7 | use std::process::Command;
  |     ^^^^^^^^^^^^^^^^^^^^^

warning: unused import: `std::str::FromStr`
 --> src/mine.rs:8:5
  |
8 | use std::str::FromStr;
  |     ^^^^^^^^^^^^^^^^^

warning: unused import: `bs58`
 --> src/mine.rs:9:5
  |
9 | use bs58;
  |     ^^^^

warning: unused import: `hex`
  --> src/mine.rs:10:5
   |
10 | use hex;
   |     ^^^

warning: unused import: `encode`
  --> src/mine.rs:24:14
   |
24 | use base64::{encode};
   |              ^^^^^^

warning: unused imports: `AsyncBufReadExt`, `BufReader`
  --> src/mine.rs:25:32
   |
25 | use tokio::io::{AsyncWriteExt, BufReader, AsyncBufReadExt};
   |                                ^^^^^^^^^  ^^^^^^^^^^^^^^^
```