### PR TITLE
Remove unused code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -128,16 +128,7 @@ struct RewardsArgs {
 }
 
 #[derive(Parser, Debug)]
-struct MineArgs {
-    #[arg(
-        long,
-        short,
-        value_name = "THREAD_COUNT",
-        help = "The number of threads to dedicate to mining",
-        default_value = "1"
-    )]
-    threads: u64,
-}
+struct MineArgs {}
 
 #[derive(Parser, Debug)]
 struct TreasuryArgs {}
@@ -214,8 +205,8 @@ async fn main() {
         Commands::Treasury(_) => {
             miner.treasury().await;
         }
-        Commands::Mine(args) => {
-            miner.mine(args.threads).await;
+        Commands::Mine(_) => {
+            miner.mine().await;
         }
         Commands::Claim(args) => {
             miner.claim(args.beneficiary, args.amount).await;

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -158,13 +158,6 @@ impl Miner {
         difficulty: &solana_sdk::keccak::Hash,
         hash_and_pubkey: &[(solana_sdk::keccak::Hash, Pubkey)]
     ) -> (KeccakHash, u64) {
-        let found_solution = Arc::new(AtomicBool::new(false));
-        let solution = Arc::new(Mutex::<(KeccakHash, u64)>::new((
-            KeccakHash::new_from_array([0; 32]),
-            0,
-        )));
-        let signer = self.signer();
-        let pubkey = signer.pubkey();
 
     let mut child = tokio::process::Command::new("PATH_TO_EXE")
     .stdin(std::process::Stdio::piped())

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -59,7 +59,7 @@ impl Miner {
             // Submit mine tx.
             // Use busses randomly so on each epoch, transactions don't pile on the same busses
             println!("\n\nSubmitting hash for validation...");
-            'submit: loop {
+            '_submit: loop {
                 // Double check we're submitting for the right challenge
                 let proof_ = get_proof(&self.rpc_client, signer.pubkey()).await;
                 if !self.validate_hash(

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -26,7 +26,7 @@ use tokio::io::{AsyncWriteExt, BufReader, AsyncBufReadExt};
 const RESET_ODDS: u64 = 20;
 
 impl Miner {
-    pub async fn mine(&self, threads: u64) {
+    pub async fn mine(&self) {
         // Register, if needed.
         let signer = self.signer();
         self.register().await;
@@ -53,7 +53,7 @@ impl Miner {
             println!("Calling find_next_hash_par");
             let hash_and_pubkey = [(solana_sdk::keccak::Hash::new_from_array(proof.hash.0),signer.pubkey())];
             let (next_hash, nonce) =
-                self.find_next_hash_par(&treasury.difficulty.into(),&hash_and_pubkey, 0).await;
+                self.find_next_hash_par(&treasury.difficulty.into(),&hash_and_pubkey).await;
                 println!("Called find_next_hash_par");
                 println!("{} {}",next_hash, nonce);
             // Submit mine tx.
@@ -156,8 +156,7 @@ impl Miner {
     async fn  find_next_hash_par(
         &self,
         difficulty: &solana_sdk::keccak::Hash,
-        hash_and_pubkey: &[(solana_sdk::keccak::Hash, Pubkey)],
-        threads: usize
+        hash_and_pubkey: &[(solana_sdk::keccak::Hash, Pubkey)]
     ) -> (KeccakHash, u64) {
         let found_solution = Arc::new(AtomicBool::new(false));
         let solution = Arc::new(Mutex::<(KeccakHash, u64)>::new((


### PR DESCRIPTION
Since this was ported to use the GPU for mining instead of CPU, there's some now unused code that can be removed.

This PR removes:
- references to number of CPU threads
- unused memory allocations (why allocate memory at all if it's not being used)
- additional unused variables

It eliminates the following compiler warnings:

```
warning: unused variable: `threads`
  --> src/mine.rs:30:30
/target
   |
30 |     pub async fn mine(&self, threads: u64) {
   |                              ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_threads`
   |
   = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `threads`
   --> src/mine.rs:161:9
    |
161 |         threads: usize
    |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_threads`

warning: unused variable: `found_solution`
   --> src/mine.rs:163:13
    |
163 |         let found_solution = Arc::new(AtomicBool::new(false));
    |             ^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_found_solution`

warning: unused variable: `solution`
   --> src/mine.rs:164:13
    |
164 |         let solution = Arc::new(Mutex::<(KeccakHash, u64)>::new((
    |             ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_solution`

warning: unused variable: `pubkey`
   --> src/mine.rs:169:13
    |
169 |         let pubkey = signer.pubkey();
    |             ^^^^^^ help: if this is intentional, prefix it with an underscore: `_pubkey`
```